### PR TITLE
fix device cannot input word "win" and "can", update workflow on device

### DIFF
--- a/legacy/common.c
+++ b/legacy/common.c
@@ -39,7 +39,7 @@ uint8_t g_uchash_mode = 0;
 // 2:U2F authenticate,use hard algorithm if se is enabled
 uint8_t g_ucSignU2F = 0;
 
-uint8_t msg_in_buffer[MSG_IN_BUFFER_SIZE];
+uint8_t msg_in_buffer[MSG_IN_BUFFER_SIZE] __attribute__((aligned(4)));
 
 static HMAC_DRBG_CTX drbg_ctx;
 

--- a/legacy/firmware/chinese.c
+++ b/legacy/firmware/chinese.c
@@ -12,6 +12,9 @@ int oledStringWidthAdapter(const char *text, uint8_t font) {
            ((font & FONT_DOUBLE) ? 2 : 1);
       text++;
     } else {
+      if (font_dese->idx == DEFAULT_IDX) {
+        font_dese = find_font("dingmao_9x9");
+      }
       l += font_dese->width + ((font & FONT_DOUBLE) ? 2 : 1);
       text += HZ_CODE_LEN;
     }

--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -1162,7 +1162,8 @@ uint32_t config_getAutoLockDelayMs() {
 }
 
 void config_setAutoLockDelayMs(uint32_t auto_lock_delay_ms) {
-  auto_lock_delay_ms = MAX(auto_lock_delay_ms, MIN_AUTOLOCK_DELAY_MS);
+  if (auto_lock_delay_ms != 0)
+    auto_lock_delay_ms = MAX(auto_lock_delay_ms, MIN_AUTOLOCK_DELAY_MS);
   if (sectrue == storage_set(KEY_AUTO_LOCK_DELAY_MS, &auto_lock_delay_ms,
                              sizeof(auto_lock_delay_ms))) {
     autoLockDelayMs = auto_lock_delay_ms;
@@ -1183,7 +1184,8 @@ uint32_t config_getSleepDelayMs(void) {
 }
 
 void config_setSleepDelayMs(uint32_t auto_sleep_ms) {
-  auto_sleep_ms = MAX(auto_sleep_ms, MIN_AUTOLOCK_DELAY_MS);
+  if (auto_sleep_ms != 0)
+    auto_sleep_ms = MAX(auto_sleep_ms, MIN_AUTOLOCK_DELAY_MS);
   if (sectrue ==
       storage_set(KEY_SLEEP_DELAY_MS, &auto_sleep_ms, sizeof(auto_sleep_ms))) {
     autoSleepDelayMs = auto_sleep_ms;

--- a/legacy/firmware/language.c
+++ b/legacy/firmware/language.c
@@ -11,7 +11,7 @@ const char *languages[][2] = {
     // fsm_msg_coin.h
     {"Abort", "取消"},
     // menu.c
-    {"About", "关于设备"},
+    {"About", "关于本机"},
     // layout2.c
     {"Absolute Levy", ""},
     //
@@ -30,6 +30,8 @@ const char *languages[][2] = {
     {"Already registered.", "已注册"},
     // u2f.c
     {"Another U2F device", "另外的U2F设备"},
+    //
+    {"Are you sure to reset?", "确定要重置吗?"},
     // u2f.c
     {"Authenticate", "认证"},
     // fsm_msg_common.h
@@ -88,9 +90,11 @@ const char *languages[][2] = {
     // ethereum.c
     {"Chain Id out of bounds", ""},  // msg
     //
-    {"Change PIN", "修改密码"},
+    {"Change PIN", "修改PIN码"},
     // layout2.c
     {"Change language to", "设置语言为"},
+    //
+    {"Check Mnemonic", "查看助记词"},
     //
     {"Check the seed", "检查助记词"},
     // layout2.c
@@ -164,6 +168,8 @@ const char *languages[][2] = {
     {"Device ID:", "设备ID:"},
     // reset.c reset.c
     {"Device failed initialized", ""},  // msg
+    //
+    {"Device has been reset", "设备已重置"},
     // fsm.c
     {"Device is already initialized. Use Wipe first.", ""},  // msg
     // fsm_msg_common.h fsm_msg_common.h
@@ -172,6 +178,8 @@ const char *languages[][2] = {
     {"Device not initialized", ""},  // msg
     // recovery.c
     {"Device recovered", ""},  // msg
+    //
+    {"Device reset in progress", "设备重置中"},
     // reset.c reset.c reset.c fsm_msg_common.h
     {"Device successfully initialized", ""},  // msg
     // fsm_msg_common.h
@@ -210,11 +218,11 @@ const char *languages[][2] = {
     // layout2.c
     {"Encrypted message", "加密信息"},
     // layout2.c layout2.c
-    {"English", "中文"},
+    {"English", "简体中文"},
     //
-    {"Enter PIN to unlock", "输入密码解锁"},
+    {"Enter PIN to unlock", "输入PIN码解锁"},
     // protect.c
-    {"Enter new wipe code:", "输入新的擦除密码"},
+    {"Enter new wipe code:", "输入新的擦除PIN码"},
     //
     {"Enter seed phrase ", "输入助记词"},
     //
@@ -291,7 +299,7 @@ const char *languages[][2] = {
     // fsm_msg_common.h
     {"If import seed,", "如果导入种子"},
     //
-    {"Inconsistent PIN code", "两次密码输入不一致"},
+    {"Inconsistent PIN code", "两次PIN码输入不一致"},
     // fsm_msg_ethereum.h
     {"Invalid address", ""},  // msg
     // signing.c
@@ -308,6 +316,8 @@ const char *languages[][2] = {
     {"Invalid identity", ""},  // msg
     // lisk.c
     {"Invalid recipient_id", ""},  // msg
+    //
+    {"Invalid seed phrases", "助记词无效"},
     // fsm_msg_common.h
     {"Invalid seed strength", ""},  // msg
     // recovery.c
@@ -323,7 +333,7 @@ const char *languages[][2] = {
     // layout2.c
     {"Label:", "设备名称:"},
     // layout2.c layout2.c
-    {"Language", "语言设置"},
+    {"Language", "语言"},
     // layout2.c
     {"Levy is", ""},
     // fsm_msg_common.h
@@ -334,6 +344,8 @@ const char *languages[][2] = {
     {"Locktime for this", "该交易时间锁定"},
     // layout2.c
     {"Login to:", "登录到"},
+    //
+    {"Make sure you still have", "请确保您仍掌握"},
     // ethereum.c
     {"Malformed address", ""},
     // ethereum.c
@@ -360,6 +372,8 @@ const char *languages[][2] = {
     {"Multisig field provided but not expected.", ""},
     // layout2.c
     {"Need Backup", "未备份"},
+    //
+    {"Never", "永不"},
     // layout2.c
     {"Next", "继续"},
     //
@@ -420,15 +434,15 @@ const char *languages[][2] = {
     {"Output's address_n provided but not expected.", ""},
     // protect.c protect.c protect.c protect.c protect.c
     // protect.c
-    {"PIN REF Table", "密码对照表"},
+    {"PIN REF Table", "PIN码对照表"},
     // fsm.c
     {"PIN cancelled", ""},
     // fsm_msg_common.h
-    {"PIN code change", "密码修改"},
+    {"PIN code change", "PIN码修改"},
     // fsm.c
     {"PIN expected", ""},
     // fsm.c
-    {"PIN invalid", "密码不正确"},
+    {"PIN invalid", "PIN码错误"},
     // fsm.c
     {"PIN mismatch", "两次输入不相同"},
     // fsm_msg_common.h fsm_msg_common.h
@@ -446,27 +460,29 @@ const char *languages[][2] = {
     // layout2.c
     {"Please check the written", "请检查写下的"},
     // protect.c protect.c
-    {"Please confirm PIN", "请确认密码"},
+    {"Please confirm PIN", "请确认PIN码"},
     // protect.c
-    {"Please enter currnet PIN", "请输入当前密码"},
+    {"Please enter currnet PIN", "请输入当前PIN码"},
     // protect.c
-    {"Please enter new PIN", "请输入新密码"},
+    {"Please enter new PIN", "请输入新PIN码"},
     // recovery.c
     {"Please enter the", "请输入"},
     // protect.c
     {"Please enter your", "请输入你的"},
     // protect.c
-    {"Please enter your PIN:", "请输入密码"},
+    {"Please enter your PIN:", "请输入PIN码"},
     // layout2.c
-    {"Please input PIN", "请输入密码"},
+    {"Please input PIN", "请输入PIN码"},
     // protect.c
-    {"Please re-enter new PIN", "请再次输入新密码"},
+    {"Please re-enter new PIN", "请再次输入新PIN码"},
+    //
+    {"Please reboot", "请重启设备"},
     // bl_check.c
     {"Please reconnect", ""},
     // recovery.c
     {"Please select the", "请选择"},
     //
-    {"Please set the PIN", "请设置密码"},
+    {"Please set the PIN", "请设置PIN码"},
     //
     {"Please try again", "请重试"},
     // protect.c
@@ -536,7 +552,7 @@ const char *languages[][2] = {
     // fsm_msg_common.h
     {"Settings applied", ""},
     // layout2.c layout2.c
-    {"Shutdown", "关机时间"},
+    {"Shutdown", "自动关机"},
     // layout2.c
     {"Sign binary message?", ""},
     // layout2.c
@@ -574,10 +590,14 @@ const char *languages[][2] = {
     {"The seed is valid and matches the one in the device", ""},
     // recovery.c
     {"The seed is valid but does not match the one in the device", ""},
+    //
+    {"The seed phrases are the", " "},
     // protect.c
     {"The wipe code must be different from your PIN.", ""},
     // u2f.c
     {"This U2F device is", ""},
+    //
+    {"This cannot be undo!", "本操作不可撤销!"},
     // protect.c fsm_msg_common.h
     {"This firmware is incapable of passphrase entry on the device.", ""},
     // signing.c fsm_msg_coin.h
@@ -677,6 +697,8 @@ const char *languages[][2] = {
     {"Write down", "请抄写助记词"},
     // layout2.c
     {"Write down your ", "请抄写你的"},
+    //
+    {"Wrong PIN for ", "您已输错"},
     // fsm_msg_coin.h
     {"Wrong address path", ""},
     // signing.c signing.c
@@ -686,6 +708,8 @@ const char *languages[][2] = {
     // layout2.c layout2.c layout2.c layout2.c
     // layout2.c
     {"Yes", "是"},
+    //
+    {"You still have 5 times", "连续输入5次将重置设备"},
     // layout2.c
     {"active device", "激活设备"},
     // fsm_msg_common.h
@@ -708,8 +732,12 @@ const char *languages[][2] = {
     {"and network fee of", ""},
     // fsm_msg_common.h
     {"answer to ping?", ""},
+    //
+    {"asset,Keep it safe", "凭证,请妥善保管"},
     // layout2.c
     {"auto-lock your device", ""},
+    //
+    {"backup of seed phrases", "助记词的物理备份"},
     // fsm_msg_common.h
     {"backup only", "仅备份"},
     //
@@ -718,10 +746,12 @@ const char *languages[][2] = {
     {"broken.", ""},
     // recovery.c
     {"but does NOT MATCH", ""},
+    //
+    {"chances", "次机会"},
     // fsm_msg_common.h
     {"change bluetooth", ""},
     // fsm_msg_common.h
-    {"change current PIN?", "修改密码"},
+    {"change current PIN?", "修改PIN码"},
     // fsm_msg_common.h
     {"change fastpay settings", "修改快捷支付"},
     // fsm_msg_common.h
@@ -800,6 +830,8 @@ const char *languages[][2] = {
     {"of your mnemonic", "助记词"},
     // recovery.c
     {"on your computer", "在电脑上"},
+    //
+    {"only way to recover your", "助记词是找回资产唯一"},
     // fsm_msg_coin.h
     {"own risk!", "风险"},
     // protect.c
@@ -839,7 +871,7 @@ const char *languages[][2] = {
     // fsm_msg_common.h
     {"set a new wipe code?", ""},
     // fsm_msg_common.h
-    {"set new PIN?", "设置密码"},
+    {"set new PIN?", "设置PIN码"},
     // fsm_msg_common.h
     {"status always?", ""},
     // bl_check.c
@@ -854,6 +886,8 @@ const char *languages[][2] = {
     {"the passphrase!", "密语"},
     // layout2.c
     {"the same mosaic", ""},
+    //
+    {"times", "次"},
     //
     {"timestamp:", "时间戳:"},
     // protect.c
@@ -873,11 +907,12 @@ const char *languages[][2] = {
     // u2f.c
     {"was used to register", "注册"},
     // fsm_msg_common.h
-    {"wipe code?", "擦除密码"},
+    {"wipe code?", "擦除PIN码"},
     // fsm_msg_common.h
     {"wipe the device?", "擦除设备"},
-
+    //
     {"word", "单词"},
-};
+    //
+    {"you still have ", "还有"}};
 
 int LANGUAGE_ITEMS = sizeof(languages) / sizeof(languages[0]);

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -2039,6 +2039,7 @@ refresh_menu:
 
 void layoutEnterSleep(void) {
 #if !EMULATOR
+  if (config_getSleepDelayMs() == 0) return;
   if (timer_get_sleep_count() >= config_getSleepDelayMs()) {
     enter_sleep();
   }

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -1590,8 +1590,10 @@ void layoutHomeInfo(void) {
     refreshUsbConnectTips();
 #endif
     if (key == KEY_UP || key == KEY_DOWN || key == KEY_CONFIRM) {
-      if (protectPinOnDevice(true)) {
+      if (protectPinOnDevice(true, true)) {
         menu_run(KEY_NULL, 0);
+      } else {
+        layoutHome();
       }
     }
   } else if (layoutLast == menu_run) {
@@ -1822,7 +1824,8 @@ void layoutItemsSelect(int x, int y, const char *text, uint8_t font) {
   oledRefresh();
 }
 
-void layoutInputPin(uint8_t pos, const char *text, const char *init_number) {
+void layoutInputPin(uint8_t pos, const char *text, const char *init_number,
+                    bool cancel_allowed) {
   int l, y = 9;
   char pin_show[] = "_  _  _  _  _  _";
 
@@ -1837,7 +1840,8 @@ void layoutInputPin(uint8_t pos, const char *text, const char *init_number) {
 
   layoutItemsSelect(64 - l / 2 + pos * 10, y, init_number,
                     FONT_STANDARD | FONT_DOUBLE);
-  layoutButtonNoAdapter(_("Cancel"), &bmp_btn_cancel);
+  if (pos != 0 || cancel_allowed)
+    layoutButtonNoAdapter(_("Cancel"), &bmp_btn_cancel);
   if (pos < 5) {
     layoutButtonYesAdapter(_("Confirm"), &bmp_btn_forward);
   } else {

--- a/legacy/firmware/layout2.h
+++ b/legacy/firmware/layout2.h
@@ -135,7 +135,8 @@ void layoutItemsSelectAdapter(const BITMAP *bmp_up, const BITMAP *bmp_down,
                               const char *prefex, const char *current,
                               const char *previous, const char *next);
 
-void layoutInputPin(uint8_t pos, const char *text, const char *init_number);
+void layoutInputPin(uint8_t pos, const char *text, const char *init_number,
+                    bool cancel_allowed);
 
 void layoutInputWord(const char *text, uint8_t prefix_len, const char *prefix,
                      const char *letter);

--- a/legacy/firmware/layout2.h
+++ b/legacy/firmware/layout2.h
@@ -144,11 +144,10 @@ void layoutInputWord(const char *text, uint8_t prefix_len, const char *prefix,
 void layoutDeviceParameters(int num);
 void layoutEnterSleep(void);
 
-#define layoutMenuItems(bmp_up, bmp_down, index, count, title, current,       \
-                        previous, next)                                       \
-  layoutItemsSelectAdapter(bmp_up, bmp_down, &bmp_btn_back, &bmp_btn_confirm, \
-                           _("Back"), _("Okay"), index, count, title, NULL,   \
-                           current, previous, next)
+#define layoutMenuItems(index, count, title, current, previous, next)     \
+  layoutItemsSelectAdapter(&bmp_btn_up, &bmp_btn_down, &bmp_btn_back,     \
+                           &bmp_btn_confirm, _("Back"), _("Okay"), index, \
+                           count, title, NULL, current, previous, next)
 
 uint8_t layoutStatusLogoEx(bool need_fresh, bool force_fresh);
 

--- a/legacy/firmware/menu_core.c
+++ b/legacy/firmware/menu_core.c
@@ -25,9 +25,8 @@ void menu_display(struct menu *menu) {
   }
 
   layoutMenuItems(
-      &bmp_btn_up, &bmp_btn_down, menu->current + 1, menu->counts,
-      menu->title ? _(menu->title) : NULL, desc,
-      menu->current > 0 ? _(menu->items[menu->current - 1].name) : NULL,
+      menu->current + 1, menu->counts, menu->title ? _(menu->title) : NULL,
+      desc, menu->current > 0 ? _(menu->items[menu->current - 1].name) : NULL,
       menu->current < menu->counts - 1 ? _(menu->items[menu->current + 1].name)
                                        : NULL);
 }

--- a/legacy/firmware/menu_list.c
+++ b/legacy/firmware/menu_list.c
@@ -16,7 +16,7 @@ static struct menu settings_menu, main_menu;
 void menu_recovery_device(int index) {
   (void)index;
   uint8_t key = KEY_NULL;
-  if (!protectPinOnDevice(true)) {
+  if (!protectPinOnDevice(true, true)) {
     return;
   }
   layoutDialogSwipeCenterAdapter(
@@ -39,7 +39,7 @@ void menu_recovery_device(int index) {
 void menu_reset_device(int index) {
   (void)index;
   uint8_t key = KEY_NULL;
-  if (!protectPinOnDevice(true)) {
+  if (!protectPinOnDevice(true, true)) {
     return;
   }
   layoutDialogSwipeCenterAdapter(
@@ -129,7 +129,7 @@ void menu_erase_device(int index) {
   if (key != KEY_CONFIRM) {
     return;
   }
-  if (!protectPinOnDevice(false)) {
+  if (!protectPinOnDevice(false, true)) {
     return;
   }
   layoutDialogSwipeCenterAdapter(
@@ -157,7 +157,7 @@ void menu_changePin(int index) {
 
 void menu_showMnemonic(int index) {
   (void)index;
-  if (protectPinOnDevice(false)) {
+  if (protectPinOnDevice(false, true)) {
     char mnemonic[MAX_MNEMONIC_LEN + 1] = {0};
     config_getMnemonic(mnemonic, sizeof(mnemonic));
     scroll_mnemonic(_("Mnemonic"), mnemonic, 0);

--- a/legacy/firmware/menu_list.c
+++ b/legacy/firmware/menu_list.c
@@ -207,7 +207,8 @@ static struct menu_item autolock_set_menu_items[] = {
     {"1", "minute", true, menu_para_set_sleep, NULL},
     {"2", "minutes", true, menu_para_set_sleep, NULL},
     {"5", "minutes", true, menu_para_set_sleep, NULL},
-    {"10", "minutes", true, menu_para_set_sleep, NULL}};
+    {"10", "minutes", true, menu_para_set_sleep, NULL},
+    {"Never", NULL, true, menu_para_set_sleep, NULL}};
 
 static struct menu autolock_set_menu = {
     .start = 0,
@@ -222,7 +223,8 @@ static struct menu_item shutdown_set_menu_items[] = {
     {"10", "minute", true, menu_para_set_shutdown, NULL},
     {"30", "minutes", true, menu_para_set_shutdown, NULL},
     {"1", "hour", true, menu_para_set_shutdown, NULL},
-    {"2", "hours", true, menu_para_set_shutdown, NULL}};
+    {"2", "hours", true, menu_para_set_shutdown, NULL},
+    {"Never", NULL, true, menu_para_set_shutdown, NULL}};
 
 static struct menu shutdown_set_menu = {
     .start = 0,

--- a/legacy/firmware/menu_list.c
+++ b/legacy/firmware/menu_list.c
@@ -11,6 +11,8 @@
 #include "recovery.h"
 #include "reset.h"
 
+extern uint8_t ui_language;
+
 static struct menu settings_menu, main_menu;
 
 void menu_recovery_device(int index) {
@@ -146,8 +148,19 @@ void menu_erase_device(int index) {
   if (key != KEY_CONFIRM) {
     return;
   }
+  uint8_t ui_language_bak = ui_language;
+
   config_wipe();
-  layoutHome();
+  if (ui_language_bak) {
+    ui_language = ui_language_bak;
+  }
+  layoutDialogSwipeCenterAdapter(NULL, NULL, &bmp_btn_confirm, _("Confirm"),
+                                 NULL, NULL, NULL, _("Device has been reset"),
+                                 NULL, _("Please reboot"), NULL);
+  protectWaitKey(0, 0);
+#if !EMULATOR
+  svc_system_reset();
+#endif
 }
 
 void menu_changePin(int index) {
@@ -161,7 +174,6 @@ void menu_showMnemonic(int index) {
     char mnemonic[MAX_MNEMONIC_LEN + 1] = {0};
     config_getMnemonic(mnemonic, sizeof(mnemonic));
     scroll_mnemonic(_("Mnemonic"), mnemonic, 0);
-    layoutHome();
   }
 }
 
@@ -180,7 +192,7 @@ static struct menu ble_set_menu = {
 
 static struct menu_item language_set_menu_items[] = {
     {"English ", NULL, true, menu_para_set_language, NULL},
-    {"中文", NULL, true, menu_para_set_language, NULL}};
+    {"简体中文", NULL, true, menu_para_set_language, NULL}};
 
 static struct menu language_set_menu = {
     .start = 0,
@@ -243,8 +255,8 @@ static struct menu settings_menu = {
 
 static struct menu_item security_set_menu_items[] = {
     {"Change PIN", NULL, true, menu_changePin, NULL},
-    {"Mnemonic", NULL, true, menu_showMnemonic, NULL},
-    {"Reset", NULL, true, menu_erase_device, NULL}};
+    {"Reset", NULL, true, menu_erase_device, NULL},
+    {"Check Mnemonic", NULL, true, menu_showMnemonic, NULL}};
 
 static struct menu security_set_menu = {
     .start = 0,

--- a/legacy/firmware/menu_list.c
+++ b/legacy/firmware/menu_list.c
@@ -31,22 +31,8 @@ void menu_recovery_device(int index) {
     layoutDialogSwipeCenterAdapter(
         NULL, NULL, &bmp_btn_confirm, _("Done"), NULL, NULL, NULL,
         _("Wallet Recovery Success"), NULL, NULL, NULL);
-    while (1) {
-      key = protectWaitKey(0, 1);
-      if (key == KEY_NULL) {
-        return;
-      } else if (key == KEY_CONFIRM) {
-        break;
-      }
-    }
-    layoutDialogSwipeCenterAdapter(&bmp_btn_back, _("Back"), &bmp_btn_forward,
-                                   _("Next"), NULL, NULL, NULL, NULL,
-                                   _("Please set the PIN"), NULL, NULL);
-    key = protectWaitKey(0, 1);
-    if (key != KEY_CONFIRM) {
-      return;
-    }
-    protectChangePinOnDevice();
+    protectWaitKey(0, 1);
+    layoutHome();
   }
 }
 
@@ -68,22 +54,8 @@ void menu_reset_device(int index) {
     layoutDialogSwipeCenterAdapter(NULL, NULL, &bmp_btn_confirm, _("Done"),
                                    NULL, NULL, NULL, _("Wallet created"),
                                    _("successfully"), NULL, NULL);
-    while (1) {
-      key = protectWaitKey(0, 1);
-      if (key == KEY_NULL) {
-        return;
-      } else if (key == KEY_CONFIRM) {
-        break;
-      }
-    }
-    layoutDialogSwipeCenterAdapter(&bmp_btn_back, _("Back"), &bmp_btn_forward,
-                                   _("Next"), NULL, NULL, NULL, NULL,
-                                   _("Please set the PIN"), NULL, NULL);
-    key = protectWaitKey(0, 1);
-    if (key != KEY_CONFIRM) {
-      return;
-    }
-    protectChangePinOnDevice();
+    protectWaitKey(0, 1);
+    layoutHome();
   }
 }
 
@@ -118,7 +90,6 @@ refresh_menu:
 
       oledDrawBitmap(60, OLED_HEIGHT - 8, &bmp_btn_down);
 
-      oledRefresh();
       break;
     case 1:
       layoutQRCode(index_str, &bmp_btn_up, &bmp_btn_down, _("Download Onekey"),
@@ -130,8 +101,9 @@ refresh_menu:
                    "https://onekey.zendesk.com/hc/zh-cn/articles/360002123856");
       break;
   }
-
-  key = protectWaitKey(timer1s * 30, 0);
+  layoutButtonYesAdapter(_("Okay"), &bmp_btn_confirm);
+  oledRefresh();
+  key = protectWaitKey(0, 0);
   switch (key) {
     case KEY_DOWN:
     case KEY_CONFIRM:
@@ -150,21 +122,37 @@ refresh_menu:
 void menu_erase_device(int index) {
   (void)index;
   uint8_t key = KEY_NULL;
-  layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
-                    _("Do you really want to"), _("wipe the device?"), NULL,
-                    _("All data will be lost."), NULL, NULL);
-  key = protectWaitKey(timer1s * 60, 1);
-  if (key == KEY_CONFIRM) {
-    if (protectPinOnDevice(true)) {
-      config_wipe();
-    }
+  layoutDialogSwipeCenterAdapter(
+      &bmp_btn_back, _("Back"), &bmp_btn_forward, _("Next"), NULL, NULL, NULL,
+      _("Make sure you still have"), _("backup of seed phrases"), NULL, NULL);
+  key = protectWaitKey(0, 1);
+  if (key != KEY_CONFIRM) {
+    return;
   }
+  if (!protectPinOnDevice(false)) {
+    return;
+  }
+  layoutDialogSwipeCenterAdapter(
+      &bmp_btn_back, _("Back"), &bmp_btn_forward, _("Next"), NULL, NULL, NULL,
+      _("All data will be lost."), _("This cannot be undo!"), NULL, NULL);
+  key = protectWaitKey(0, 1);
+  if (key != KEY_CONFIRM) {
+    return;
+  }
+  layoutDialogSwipeCenterAdapter(&bmp_btn_back, _("Back"), &bmp_btn_confirm,
+                                 _("Reset"), NULL, NULL, NULL, NULL,
+                                 _("Are you sure to reset?"), NULL, NULL);
+  key = protectWaitKey(0, 1);
+  if (key != KEY_CONFIRM) {
+    return;
+  }
+  config_wipe();
   layoutHome();
 }
 
 void menu_changePin(int index) {
   (void)index;
-  protectChangePinOnDevice();
+  protectChangePinOnDevice(true);
 }
 
 void menu_showMnemonic(int index) {

--- a/legacy/firmware/menu_para.c
+++ b/legacy/firmware/menu_para.c
@@ -10,6 +10,10 @@ static char* format_time(uint32_t ms) {
   static char line[sizeof("4294967296 minutes?")] = {0};
 
   const char* unit = _("second");
+
+  if (ms == 0) {
+    return _("Never");
+  }
   uint32_t num = ms / 1000U;
 
   if (ms >= 60 * 60 * 1000) {
@@ -56,12 +60,12 @@ void menu_para_set_language(int index) {
 }
 
 void menu_para_set_shutdown(int index) {
-  uint32_t ms[4] = {10 * 60 * 1000, 30 * 60 * 1000, 60 * 60 * 1000,
-                    2 * 60 * 60 * 1000};
+  uint32_t ms[5] = {10 * 60 * 1000, 30 * 60 * 1000, 60 * 60 * 1000,
+                    2 * 60 * 60 * 1000, 0};
   config_setAutoLockDelayMs(ms[index]);
 }
 
 void menu_para_set_sleep(int index) {
-  uint32_t ms[4] = {60 * 1000, 2 * 60 * 1000, 5 * 60 * 1000, 10 * 60 * 1000};
+  uint32_t ms[5] = {60 * 1000, 2 * 60 * 1000, 5 * 60 * 1000, 10 * 60 * 1000, 0};
   config_setSleepDelayMs(ms[index]);
 }

--- a/legacy/firmware/protect.c
+++ b/legacy/firmware/protect.c
@@ -248,7 +248,7 @@ const char *requestPin(PinMatrixRequestType type, const char *text,
       else
         return 0;
     } else if (msg_tiny_id == MessageType_MessageType_BixinPinInputOnDevice) {
-      return protectInputPin(text, 6);
+      return protectInputPin(text, 6, true);
     }
     if (button.NoUp) {
       timer_out_set(timer_out_oper, 0);
@@ -366,7 +366,7 @@ bool protectChangePin(bool removal) {
     if (g_bIsBixinAPP) {
       need_new_pin = false;
       if (newpin == NULL) {
-        newpin = protectInputPin(_("Please enter new PIN"), 6);
+        newpin = protectInputPin(_("Please enter new PIN"), 6, true);
       }
     }
     if (pin == NULL) {
@@ -702,7 +702,8 @@ uint8_t protectWaitKey(uint32_t time_out, uint8_t mode) {
   return key;
 }
 
-const char *protectInputPin(const char *text, uint8_t pin_len) {
+const char *protectInputPin(const char *text, uint8_t pin_len,
+                            bool cancel_allowed) {
   uint8_t key = KEY_NULL;
   uint8_t counter = 0;
   char value[2] = "1";
@@ -710,7 +711,7 @@ const char *protectInputPin(const char *text, uint8_t pin_len) {
 
   memzero(pin, sizeof(pin));
 refresh_menu:
-  layoutInputPin(counter, text, value);
+  layoutInputPin(counter, text, value, cancel_allowed);
   key = protectWaitKey(0, 0);
   switch (key) {
     case KEY_UP:
@@ -739,7 +740,7 @@ refresh_menu:
   return NULL;
 }
 
-bool protectPinOnDevice(bool use_cached) {
+bool protectPinOnDevice(bool use_cached, bool cancel_allowed) {
   //   static bool input_pin = false;  // void recursive
   if (use_cached && session_isUnlocked()) {
     return true;
@@ -749,7 +750,7 @@ bool protectPinOnDevice(bool use_cached) {
 input:
   if (config_hasPin()) {
     // input_pin = true;
-    pin = protectInputPin(_("Please enter currnet PIN"), 6);
+    pin = protectInputPin(_("Please enter currnet PIN"), 6, cancel_allowed);
     // input_pin = false;
 
     if (!pin) {
@@ -778,7 +779,7 @@ bool protectChangePinOnDevice(bool is_prompt) {
   if (config_hasPin()) {
     is_change = true;
   input:
-    pin = protectInputPin(_("Please enter currnet PIN"), 6);
+    pin = protectInputPin(_("Please enter currnet PIN"), 6, true);
 
     if (pin == NULL) {
       return false;
@@ -804,7 +805,7 @@ bool protectChangePinOnDevice(bool is_prompt) {
     }
   }
 retry:
-  pin = protectInputPin(_("Please enter new PIN"), 6);
+  pin = protectInputPin(_("Please enter new PIN"), 6, true);
   if (pin == PIN_CANCELED_BY_BUTTON) {
     return false;
   } else if (pin == NULL || pin[0] == '\0') {
@@ -813,7 +814,7 @@ retry:
   }
   strlcpy(new_pin, pin, sizeof(new_pin));
 
-  pin = protectInputPin(_("Please re-enter new PIN"), 6);
+  pin = protectInputPin(_("Please re-enter new PIN"), 6, true);
   if (pin == NULL) {
     memzero(old_pin, sizeof(old_pin));
     memzero(new_pin, sizeof(new_pin));

--- a/legacy/firmware/protect.h
+++ b/legacy/firmware/protect.h
@@ -39,8 +39,9 @@ bool protectChangeWipeCode(bool removal);
 bool protectPassphrase(char* passphrase);
 bool protectSeedPin(bool force_pin, bool setpin, bool update_pin);
 uint8_t protectWaitKey(uint32_t time_out, uint8_t mode);
-const char* protectInputPin(const char* text, uint8_t pin_len);
-bool protectPinOnDevice(bool use_cached);
+const char* protectInputPin(const char* text, uint8_t pin_len,
+                            bool cancel_allowed);
+bool protectPinOnDevice(bool use_cached, bool cancel_allowed);
 bool protectChangePinOnDevice(bool is_prompt);
 bool protectSelectMnemonicNumber(uint32_t* number);
 bool protectPinCheck(void);

--- a/legacy/firmware/protect.h
+++ b/legacy/firmware/protect.h
@@ -41,7 +41,7 @@ bool protectSeedPin(bool force_pin, bool setpin, bool update_pin);
 uint8_t protectWaitKey(uint32_t time_out, uint8_t mode);
 const char* protectInputPin(const char* text, uint8_t pin_len);
 bool protectPinOnDevice(bool use_cached);
-bool protectChangePinOnDevice(void);
+bool protectChangePinOnDevice(bool is_prompt);
 bool protectSelectMnemonicNumber(uint32_t* number);
 bool protectPinCheck(void);
 extern bool protectAbortedByCancel;

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -240,6 +240,7 @@ static bool recovery_done(void) {
             NULL, NULL, &bmp_btn_retry, _("Retry"), NULL, NULL, NULL,
             _("Invalid seed phrases"), _("Please try again"), NULL, NULL);
         protectWaitKey(0, 1);
+        return false;
       }
     } else {
       layoutDialogAdapter(&bmp_icon_error, NULL, _("Confirm"), NULL,

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -624,7 +624,7 @@ void recovery_abort(void) {
   }
 }
 
-#define CANDIDATE_MAX_LEN 6
+#define CANDIDATE_MAX_LEN 8  // DO NOT CHANGE THIS
 
 static void select_complete_word(char *title, int start, int len) {
   uint8_t key = KEY_NULL;

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -185,6 +185,11 @@ static bool recovery_done(void) {
   if (!enforce_wordlist || mnemonic_check(new_mnemonic)) {
     // New mnemonic is valid.
     if (!dry_run) {
+      if (recovery_byself) {
+        if (!protectChangePinOnDevice(false)) {
+          return false;
+        }
+      }
       // Update mnemonic on config.
       if (config_setMnemonic(new_mnemonic)) {
         if (!enforce_wordlist) {
@@ -314,8 +319,7 @@ static void display_choices(bool twoColumn, char choices[9][12], int num) {
     int nr = (word_index / 4) + 1;
     format_number(desc, nr);
     layoutDialogSwipe(&bmp_icon_info, NULL, NULL, NULL, _("Please enter the"),
-                      (nr < 10 ? desc + 1 : desc), _("of your mnemonic"), NULL,
-                      NULL, NULL);
+                      desc, _("of your mnemonic"), NULL, NULL, NULL);
   } else {
     oledBox(0, 27, 127, 63, false);
   }
@@ -735,9 +739,11 @@ refresh_menu:
             mnemonic_word_index_with_prefix(words[word_index], prefix_len);
         select_complete_word(NULL, candidate_location, letter_count);
         if (word_index == word_count) {
-          layoutDialogCenterAdapter(&bmp_btn_cancel, _("Cancel"),
-                                    &bmp_btn_confirm, _("Confirm"), NULL, NULL,
-                                    NULL, _("Please check the entered"),
+          memzero(desc, sizeof(desc));
+          strcat(desc, _("Please check the entered"));
+          uint2str(word_count, desc + strlen(desc));
+          layoutDialogCenterAdapter(&bmp_btn_back, _("Back"), &bmp_btn_forward,
+                                    _("Next"), NULL, NULL, NULL, desc,
                                     _("seed phrases"), NULL, NULL);
 
           key = protectWaitKey(0, 1);

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -135,6 +135,7 @@ void enter_sleep(void) {
 }
 
 void auto_poweroff_timer(void) {
+  if (config_getAutoLockDelayMs() == 0) return;
   if (timer_get_sleep_count() >= config_getAutoLockDelayMs()) {
     if (sys_nfcState() || sys_usbState()) {
       config_lockDevice();

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -121,7 +121,7 @@ void enter_sleep(void) {
   if (unlocked) {
     if (sleep_count > 1) {
     } else {
-      while (!protectPinOnDevice(false)) {
+      while (!protectPinOnDevice(false, false)) {
       }
     }
   }

--- a/legacy/oled.c
+++ b/legacy/oled.c
@@ -125,7 +125,7 @@ static inline void SPISend(uint32_t base, const uint8_t *data, int len) {
 void oledInit() {
   static const uint8_t s[25] = {OLED_DISPLAYOFF,
                                 OLED_SETDISPLAYCLOCKDIV,
-                                0x80,
+                                0xC0,
                                 OLED_SETMULTIPLEX,
                                 0x3F,  // 128x64
                                 OLED_SETDISPLAYOFFSET,
@@ -166,6 +166,18 @@ void oledInit() {
 
   oledClear();
   oledRefresh();
+}
+
+void oledUpdateClk(void) {
+  static const uint8_t s[2] = {OLED_SETDISPLAYCLOCKDIV, 0xC0};
+
+  gpio_clear(OLED_DC_PORT, OLED_DC_PIN);  // set to CMD
+  gpio_set(OLED_CS_PORT, OLED_CS_PIN);    // SPI deselect
+
+  // init
+  gpio_clear(OLED_CS_PORT, OLED_CS_PIN);  // SPI select
+  SPISend(SPI_BASE, s, 2);
+  gpio_set(OLED_CS_PORT, OLED_CS_PIN);  // SPI deselect
 }
 #endif
 

--- a/legacy/oled.h
+++ b/legacy/oled.h
@@ -54,6 +54,8 @@ void oledInit(void);
 void oledClear(void);
 void oledClearPart(void);
 
+void oledUpdateClk(void);
+
 void oledRefresh(void);
 
 void oledSetDebugLink(bool set);

--- a/legacy/setup.c
+++ b/legacy/setup.c
@@ -186,6 +186,9 @@ void setupApp(void) {
   gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_PULLUP, GPIO10);
   gpio_set_af(GPIOA, GPIO_AF10, GPIO10);
 
+  // change oled refresh frequency
+  oledUpdateClk();
+
   // master i2c init
   vMI2CDRV_Init();
 }


### PR DESCRIPTION
修复恢复钱包助记词无效时，点击重试，设备显示“等待连接”  OneKeyHQ/TaskHub#653
修改硬件恢复出厂后需重启设备  OneKeyHQ/TaskHub#651
修复设备不能输入单词“win"和”can" OneKeyHQ/TaskHub#650
改善手机拍照时屏幕闪的问题 OneKeyHQ/TaskHub#645
修改设备创建和恢复钱包流程 OneKeyHQ/TaskHub#630
重置设备需要在PIN码 OneKeyHQ/TaskHub#628
输入PIN 取消后刷新 OneKeyHQ/TaskHub#602
设备与上位机通讯更新关机时间 OneKeyHQ/TaskHub#574
优化显示 OneKeyHQ/TaskHub#516，OneKeyHQ/TaskHub#588， OneKeyHQ/TaskHub#590
锁屏和关机时间支持永不参数