### PR TITLE
avoid using same word during verify mnemonic，use random number to initial pin

### DIFF
--- a/legacy/firmware/language.c
+++ b/legacy/firmware/language.c
@@ -475,7 +475,7 @@ const char *languages[][2] = {
     // protect.c protect.c
     {"Please confirm PIN", "请确认PIN码"},
     // protect.c
-    {"Please enter currnet PIN", "请输入当前PIN码"},
+    {"Please enter current PIN", "请输入当前PIN码"},
     // protect.c
     {"Please enter new PIN", "请输入新PIN码"},
     // recovery.c

--- a/legacy/firmware/layout2.h
+++ b/legacy/firmware/layout2.h
@@ -45,6 +45,7 @@ void layoutProgressSwipe(const char *desc, int permil);
 
 void layoutScreensaver(void);
 void layoutHome(void);
+void layoutHomeEx(void);
 void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out);
 void layoutConfirmOmni(const uint8_t *data, uint32_t size);
 void layoutConfirmOpReturn(const uint8_t *data, uint32_t size);

--- a/legacy/firmware/protect.c
+++ b/legacy/firmware/protect.c
@@ -255,6 +255,8 @@ const char *requestPin(PinMatrixRequestType type, const char *text,
       else
         return 0;
     } else if (msg_tiny_id == MessageType_MessageType_BixinPinInputOnDevice) {
+      msg_tiny_id = 0xFFFF;
+      usbTiny(0);
       return protectInputPin(text, MAX_PIN_LEN, true);
     }
     if (button.NoUp) {

--- a/legacy/firmware/protect.c
+++ b/legacy/firmware/protect.c
@@ -33,6 +33,7 @@
 #include "oled.h"
 #include "pinmatrix.h"
 #include "prompt.h"
+#include "rng.h"
 #include "si2c.h"
 #include "sys.h"
 #include "usb.h"
@@ -720,10 +721,14 @@ const char *protectInputPin(const char *text, uint8_t pin_len,
                             bool cancel_allowed) {
   uint8_t key = KEY_NULL;
   uint8_t counter = 0;
-  int index = 1;
+  int index = 0;
   static char pin[10] = "";
 
   memzero(pin, sizeof(pin));
+  do {
+    index = random_uniform(10);
+  } while (index == 0);
+
 refresh_menu:
   layoutInputPin(counter, text, index, cancel_allowed);
   key = protectWaitKey(0, 0);
@@ -758,14 +763,19 @@ refresh_menu:
       } else {
         pin[counter++] = index + '0';
         if (counter == pin_len) return pin;
-        index = 1;
+        do {
+          index = random_uniform(10);
+        } while (index == 0);
+
         goto refresh_menu;
       }
     case KEY_CANCEL:
       if (counter) {
-        pin[counter] = 0;
         counter--;
-        index = 1;
+        pin[counter] = 0;
+        do {
+          index = random_uniform(10);
+        } while (index == 0);
         goto refresh_menu;
       }
       break;

--- a/legacy/firmware/protect.c
+++ b/legacy/firmware/protect.c
@@ -795,7 +795,7 @@ bool protectPinOnDevice(bool use_cached, bool cancel_allowed) {
 input:
   if (config_hasPin()) {
     // input_pin = true;
-    pin = protectInputPin(_("Please enter currnet PIN"), MAX_PIN_LEN,
+    pin = protectInputPin(_("Please enter current PIN"), MAX_PIN_LEN,
                           cancel_allowed);
     // input_pin = false;
     if (!pin) {
@@ -825,7 +825,7 @@ pin_set:
   if (config_hasPin()) {
     is_change = true;
   input:
-    pin = protectInputPin(_("Please enter currnet PIN"), MAX_PIN_LEN, true);
+    pin = protectInputPin(_("Please enter current PIN"), MAX_PIN_LEN, true);
 
     if (pin == NULL) {
       return false;

--- a/legacy/firmware/protect.h
+++ b/legacy/firmware/protect.h
@@ -28,6 +28,14 @@
 
 #define PIN_CANCELED_BY_BUTTON (void*)1
 
+enum {
+  SLEEP_NONE = 0x00,
+  SLEEP_ENTER = 0x01,
+  SLEEP_REENTER = 0X02,
+  SLEEP_CANCEL_BY_BUTTON = 0x03,
+  SLEEP_CANCEL_BY_USB = 0x04
+};
+
 bool protectButton(ButtonRequestType type, bool confirm_only);
 secbool protectPinUiCallback(uint32_t wait, uint32_t progress,
                              const char* message);
@@ -45,6 +53,11 @@ bool protectPinOnDevice(bool use_cached, bool cancel_allowed);
 bool protectChangePinOnDevice(bool is_prompt, bool set);
 bool protectSelectMnemonicNumber(uint32_t* number);
 bool protectPinCheck(bool retry);
+
+#if !EMULATOR
+void enter_sleep(void);
+#endif
+
 extern bool protectAbortedByCancel;
 extern bool protectAbortedByInitialize;
 extern bool protectAbortedByTimeout;

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -505,6 +505,9 @@ void recovery_init(uint32_t _word_count, bool passphrase_protection,
   if (_word_count != 12 && _word_count != 18 && _word_count != 24) return;
 
   word_count = _word_count;
+#if !EMULATOR
+  _enforce_wordlist = true;
+#endif
   enforce_wordlist = _enforce_wordlist;
   dry_run = _dry_run;
 

--- a/legacy/firmware/reset.c
+++ b/legacy/firmware/reset.c
@@ -269,7 +269,8 @@ bool verify_mnemonic(const char *mnemonic) {
   char words[24][12];
   uint32_t words_order[3];
   uint32_t i = 0, word_count = 0;
-  uint32_t index = 0, rand = 0, selected = 0;
+  uint32_t index = 0, selected = 0;
+  uint32_t rand_list[3] = {0};
 
   memzero(words, sizeof(words));
 
@@ -298,13 +299,21 @@ bool verify_mnemonic(const char *mnemonic) {
     return false;
   }
 
+  rand_list[0] = random_uniform(word_count);
+  do {
+    rand_list[1] = random_uniform(word_count);
+  } while (rand_list[1] == rand_list[0]);
+
+  do {
+    rand_list[2] = random_uniform(word_count);
+  } while (rand_list[2] == rand_list[0] || rand_list[2] == rand_list[1]);
+
 refresh_menu:
   i = 0;
   memzero(desc, sizeof(desc));
   strcat(desc, _("Select your"));
   strcat(desc, " #");
-  rand = random_uniform(word_count);
-  uint2str(rand + 1, desc + strlen(desc));
+  uint2str(rand_list[index] + 1, desc + strlen(desc));
   strcat(desc, " ");
   strcat(desc, _("mnemonic"));
   layoutDialogSwipeCenterAdapter(NULL, &bmp_btn_back, _("Back"),
@@ -314,15 +323,15 @@ refresh_menu:
   if (key != KEY_CONFIRM) {
     return false;
   }
-  selected = mnemonic_find_word(words[rand]);
+  selected = mnemonic_find_word(words[rand_list[index]]);
   words_order[0] = selected;
   do {
     words_order[1] = random_uniform(BIP39_WORDS);
-  } while (words_order[1] == rand);
+  } while (words_order[1] == selected);
 
   do {
     words_order[2] = random_uniform(BIP39_WORDS);
-  } while (words_order[2] == rand || words_order[2] == words_order[1]);
+  } while (words_order[2] == selected || words_order[2] == words_order[1]);
 
   random_order(words_order, 3);
 

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -95,51 +95,6 @@ void check_lock_screen(void) {
 }
 
 #if !EMULATOR
-extern volatile uint32_t system_millis;
-
-void enter_sleep(void) {
-  static int sleep_count = 0;
-  bool unlocked = false;
-  uint8_t oled_prev[OLED_BUFSIZE];
-  void *layoutBack = NULL;
-  bool ble_state_bak = ble_get_switch();
-  sleep_count++;
-  if (sleep_count == 1) {
-    unlocked = session_isUnlocked();
-    layoutBack = layoutLast;
-    config_lockDevice();
-  }
-  oledBufferLoad(oled_prev);
-  if (ble_state_bak) {
-    change_ble_sta(BLE_ADV_OFF_TEMP);
-  }
-  oledClear();
-  oledDrawStringCenterAdapter(OLED_WIDTH / 2, 30, _("Sleep Mode"),
-                              FONT_STANDARD);
-  layoutButtonNoAdapter(_("Exit"), NULL);
-  oledRefresh();
-  svc_system_sleep();
-  while (get_power_key_state()) {
-  }
-  timer_sleep_start_reset();
-  if (unlocked) {
-    if (sleep_count > 1) {
-    } else {
-      while (!protectPinOnDevice(false, false)) {
-      }
-    }
-  }
-  if (ble_state_bak) {
-    change_ble_sta(BLE_ADV_ON_TEMP);
-  }
-  usbInit();
-  oledBufferRestore(oled_prev);
-  oledRefresh();
-  sleep_count--;
-  if (sleep_count == 0) {
-    layoutLast = layoutBack;
-  }
-}
 
 void auto_poweroff_timer(void) {
   if (config_getAutoLockDelayMs() == 0) return;

--- a/legacy/firmware/trezor.h
+++ b/legacy/firmware/trezor.h
@@ -37,8 +37,4 @@
 /* Screen timeout */
 extern uint32_t system_millis_lock_start;
 
-#if !EMULATOR
-void enter_sleep(void);
-#endif
-
 #endif


### PR DESCRIPTION
英文拼写错误修改 OneKeyHQ/TaskHub#839
设备端输入PIN时，初始选择为随机数 OneKeyHQ/TaskHub#834
修复设备输入PIN回退操作后，正确pin验证失败 OneKeyHQ/TaskHub#825
修复随机验证助记词重复单词 OneKeyHQ/TaskHub#763，OneKeyHQ/TaskHub#758
导入助记词时，强制助记词校验为真
修复在设备输入PIN后标记未复位