### PR TITLE
legacy:fix ETH transaction display overlap problem

### DIFF
--- a/legacy/firmware/ethereum.c
+++ b/legacy/firmware/ethereum.c
@@ -277,8 +277,8 @@ static void layoutEthereumConfirmTx(const uint8_t *to, uint32_t to_len,
     ethereumFormatAmount(&val, token, amount, sizeof(amount));
   }
 
-  char _to1[] = "to 0x__________";
-  char _to2[] = "_______________";
+  char _to1[30] = "to 0x__________";
+  char _to2[30] = "_______________";
   char _to3[] = "_______________?";
 
   if (to_len) {
@@ -296,17 +296,27 @@ static void layoutEthereumConfirmTx(const uint8_t *to, uint32_t to_len,
     }
 
     ethereum_address_checksum(to, to_str, rskip60, chain_id);
-    memcpy(_to1 + 5, to_str, 10);
-    memcpy(_to2, to_str + 10, 15);
-    memcpy(_to3, to_str + 25, 15);
+    if (oledStringWidthAdapter(amount, FONT_STANDARD) > (OLED_WIDTH - 20)) {
+      memcpy(_to1 + 5, to_str, 18);
+      memcpy(_to2, to_str + 18, 22);
+    } else {
+      memcpy(_to1 + 5, to_str, 10);
+      memcpy(_to2, to_str + 10, 15);
+      memcpy(_to3, to_str + 25, 15);
+    }
+
   } else {
     strlcpy(_to1, _("to new contract?"), sizeof(_to1));
     strlcpy(_to2, "", sizeof(_to2));
     strlcpy(_to3, "", sizeof(_to3));
   }
-
-  layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
-                    _("Send"), amount, _to1, _to2, _to3, NULL);
+  if (oledStringWidthAdapter(amount, FONT_STANDARD) > (OLED_WIDTH - 20)) {
+    layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
+                      _("Send"), amount, NULL, _to1, _to2, NULL);
+  } else {
+    layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
+                      _("Send"), amount, _to1, _to2, _to3, NULL);
+  }
 }
 
 static void layoutEthereumData(const uint8_t *data, uint32_t len,
@@ -371,10 +381,19 @@ static void layoutEthereumFee(const uint8_t *value, uint32_t value_len,
   } else {
     ethereumFormatAmount(&val, NULL, tx_value, sizeof(tx_value));
   }
-
-  layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
-                    _("Really send"), tx_value, _("paying up to"), gas_value,
-                    _("for gas?"), NULL);
+  if (oledStringWidthAdapter(tx_value, FONT_STANDARD) > (OLED_WIDTH - 20)) {
+    char buf[64] = {0};
+    strcat(buf, _("paying up to"));
+    strcat(buf, _(" "));
+    strcat(buf, gas_value);
+    layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
+                      _("Really send"), tx_value, NULL, buf, _("for gas?"),
+                      NULL);
+  } else {
+    layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
+                      _("Really send"), tx_value, _("paying up to"), gas_value,
+                      _("for gas?"), NULL);
+  }
 }
 
 /*

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -1732,10 +1732,10 @@ void layoutDialogAdapter(const BITMAP *icon, const char *btnNo,
     oledDrawStringAdapter(left, 1 * (font->pixel + 1), line2, FONT_STANDARD);
   }
   if (line3) {
-    oledDrawStringAdapter(left, 2 * (font->pixel + 1), line3, FONT_STANDARD);
+    oledDrawStringAdapter(0, 2 * (font->pixel + 1), line3, FONT_STANDARD);
   }
   if (line4) {
-    oledDrawStringAdapter(left, 3 * (font->pixel + 1), line4, FONT_STANDARD);
+    oledDrawStringAdapter(0, 3 * (font->pixel + 1), line4, FONT_STANDARD);
   }
 
   if (desc) {
@@ -1747,10 +1747,10 @@ void layoutDialogAdapter(const BITMAP *icon, const char *btnNo,
     }
   } else {
     if (line5) {
-      oledDrawStringAdapter(left, 4 * (font->pixel + 1), line5, FONT_STANDARD);
+      oledDrawStringAdapter(0, 4 * (font->pixel + 1), line5, FONT_STANDARD);
     }
     if (line6) {
-      oledDrawStringAdapter(left, 5 * (font->pixel + 1), line6, FONT_STANDARD);
+      oledDrawStringAdapter(0, 5 * (font->pixel + 1), line6, FONT_STANDARD);
     }
     if (btnYes || btnNo) {
       oledHLine(OLED_HEIGHT - (font->pixel + 4));

--- a/legacy/firmware/usb.c
+++ b/legacy/firmware/usb.c
@@ -34,6 +34,7 @@
 #include "layout2.h"
 #include "memory.h"
 #include "si2c.h"
+#include "supervise.h"
 #include "sys.h"
 #include "usb.h"
 #include "util.h"
@@ -439,6 +440,7 @@ void usbPoll(void) {
     }
   }
   if (reset) {
+    svc_system_privileged();
     vector_table_t *ivt = (vector_table_t *)FLASH_PTR(FLASH_APP_START);
     __asm__ volatile("msr msp, %0" ::"r"(ivt->initial_sp_value));
     __asm__ volatile("b reset_handler");

--- a/legacy/supervise.c
+++ b/legacy/supervise.c
@@ -22,6 +22,7 @@
 #include <libopencm3/stm32/flash.h>
 #include <stdint.h>
 #include "memory.h"
+#include "util.h"
 
 #define FLASH_UTXO_CACHE_SECTOR 10
 
@@ -72,6 +73,11 @@ static void svhandler_system_reset(void) { scb_reset_core(); }
 
 static void svhandler_system_sleep(void) { enter_sleep_mode(); }
 
+static void svhandler_system_privileged(void) {
+  set_mode_privileged();
+  mpu_config_off();
+}
+
 extern volatile uint32_t system_millis;
 
 void svc_handler_main(uint32_t *stack) {
@@ -97,6 +103,9 @@ void svc_handler_main(uint32_t *stack) {
       break;
     case SVC_SYS_SLEEP:
       svhandler_system_sleep();
+      break;
+    case SVC_SYS_PRIVILEGED:
+      svhandler_system_privileged();
       break;
     default:
       stack[0] = 0xffffffff;

--- a/legacy/supervise.h
+++ b/legacy/supervise.h
@@ -32,6 +32,7 @@
 
 #define SVC_SYS_RESET 10
 #define SVC_SYS_SLEEP 11
+#define SVC_SYS_PRIVILEGED 12
 
 /* Unlocks flash.  This function needs to be called before programming
  * or erasing. Multiple calls of flash_program and flash_erase can
@@ -80,6 +81,10 @@ inline void svc_system_reset(void) {
 
 inline void svc_system_sleep(void) {
   __asm__ __volatile__("svc %0" ::"i"(SVC_SYS_SLEEP) : "memory");
+}
+
+inline void svc_system_privileged(void) {
+  __asm__ __volatile__("svc %0" ::"i"(SVC_SYS_PRIVILEGED) : "memory");
 }
 
 #else

--- a/legacy/util.h
+++ b/legacy/util.h
@@ -95,6 +95,11 @@ jump_to_firmware(const vector_table_t *ivt, int trust) {
     ;
 }
 
+static inline void set_mode_privileged(void) {
+  // http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CHDBIBGJ.html
+  __asm__ volatile("msr control, %0" ::"r"(0x0));
+}
+
 static inline void set_mode_unprivileged(void) {
   // http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CHDBIBGJ.html
   __asm__ volatile("msr control, %0" ::"r"(0x1));


### PR DESCRIPTION
解决eth转账时，金额中小数位过多显示覆盖问题 OneKeyHQ/TaskHub#1003
设备检测到插拔后，设备由解锁状态切换到锁定状态，状态更改后输入PIN解锁失败，原因是设备正常启动时处于特权状态，切换状态复位需将设备切回特权模式，关闭MPU OneKeyHQ/TaskHub#1068