### PR TITLE
legacy:ETH sign message buffer increase to 5k

### DIFF
--- a/legacy/firmware/protob/messages-ethereum.options
+++ b/legacy/firmware/protob/messages-ethereum.options
@@ -12,7 +12,7 @@ EthereumTxRequest.signature_s           max_size:32
 EthereumTxAck.data_chunk                max_size:1024
 
 EthereumSignMessage.address_n           max_count:8
-EthereumSignMessage.message             max_size:1024
+EthereumSignMessage.message             max_size:5120
 
 EthereumVerifyMessage.address           max_size:43
 EthereumVerifyMessage.signature         max_size:65


### PR DESCRIPTION
ETH签名消息支持的最大长度增加到5K